### PR TITLE
unpkg.com vervangen door jsdelivr.net

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,13 +4,13 @@
         <meta charset="UTF-8">
         <title>{% block title %}{{ 'title' | trans }}{% endblock %}</title>
         <link rel="stylesheet" href="{{ asset('app.css') }}" type="text/css" />
-        <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css" type="text/css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/dropzone@5/dist/min/dropzone.min.css" type="text/css" />
         <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}" />
     </head>
     <body>
         {% block body %}{% endblock %}
     </body>
-    <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dropzone@5/dist/min/dropzone.min.js"></script>
     <script src="{{ asset('jquery.min.js') }}"></script>
     <script src="{{ asset('app.js') }}"></script>
     {% block javascript %}{% endblock %}


### PR DESCRIPTION
unpkg.com ligt eruit, zie https://forum.beneluxspoor.net/index.php?topic=110321.msg3222465555#msg3222465555

In een issue op de unpkg repo op github werd jsdelivr.net aangeraden: https://github.com/mjackson/unpkg/issues/384#issuecomment-2051245385

Geen idee of dat een goede is, maar hij doet het op het moment in ieder geval.

(En ik hoop dat dit de goede plek is om het te veranderen, volgens github was dit het enige bestand waarin de naam voor kwam).